### PR TITLE
fix: disable BGP loop prevention for AS47065

### DIFF
--- a/configs/bird/bird.conf
+++ b/configs/bird/bird.conf
@@ -8,7 +8,7 @@ table igptable;
 
 template bgp peering {
 	local as 47065;
-	allow local as 3;
+	allow local as;
 	table rtup;
 	igp table igptable;
 	# add paths rx;

--- a/configs/bird6/bird6.conf
+++ b/configs/bird6/bird6.conf
@@ -15,7 +15,7 @@ table igptable;
 
 template bgp peering {
 	local as 47065;
-	allow local as 3;
+	allow local as;
 	table rtup;
 	igp table igptable;
 	# add paths rx;


### PR DESCRIPTION
Allow importing routes with any number of prepends for AS47065.