### PR TITLE
modify some scripts to enable support for nix

### DIFF
--- a/peering
+++ b/peering
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 progdir=$(cd "$(dirname "$0")" && pwd -P)

--- a/scripts/peering-app
+++ b/scripts/peering-app
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 usage () {

--- a/scripts/peering-bgp
+++ b/scripts/peering-bgp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 usage () {

--- a/scripts/peering-openvpn
+++ b/scripts/peering-openvpn
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 usage () {

--- a/scripts/peering-prefix
+++ b/scripts/peering-prefix
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 # program=$(basename $0)

--- a/scripts/peering-proxy
+++ b/scripts/peering-proxy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 usage () {

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 
 pkgs.mkShell {
   buildInputs = with pkgs; [
-    bird
+    bird2
     openvpn
     socat
     psmisc

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> {}}:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    bird
+    openvpn
+    socat
+    psmisc
+    ipcalc
+  ];
+}


### PR DESCRIPTION
nixos does not have /bin/bash, and `#!/usr/bin/env bash` is also more flexible. shell-nix installs the dependencies that the client needs.

!! This is still a WIP and will be ready to review once the client is confirmed working on nix.