### PR TITLE
fix: correct typo 'commnunities' to 'communities' in schema

### DIFF
--- a/configs/announcement_schema.json
+++ b/configs/announcement_schema.json
@@ -148,7 +148,7 @@
             "type": "number"
           }
         },
-        "commnunities": {
+        "communities": {
           "type": "array",
           "uniqueItems": true,
           "items": {


### PR DESCRIPTION
This PR fixes a typo in "configs/announcement_schema.json"  where the property was defined as "commnunities" instead of "communities"