### PR TITLE
fix: simplify ipcalc usage in peering-app

### DIFF
--- a/scripts/peering-app
+++ b/scripts/peering-app
@@ -92,13 +92,13 @@ fi
 minus6="-4"
 pfxlen=${prefix##*/}
 if [[ $prefix =~ : ]] ; then
-    appip=$(ipcalc -n -b "$prefix" | grep HostMin | awk '{print $2;}')
-    hostip=$(ipcalc -n -b "$prefix" | grep HostMax | awk '{print $2;}')
+    appip=$(ipcalc "$prefix" | grep HostMin | awk '{print $2;}')
+    hostip=$(ipcalc "$prefix" | grep HostMax | awk '{print $2;}')
     fprefix=$(echo "$prefix" | sed -e "s|::[0-9a-f]*/[0-9]*|::\/48|")
     minus6="-6"
 else
-    appip=$(ipcalc -n -b "$prefix" | grep HostMin | awk '{print $2;}')
-    hostip=$(ipcalc -n -b "$prefix" | grep HostMax | awk '{print $2;}')
+    appip=$(ipcalc "$prefix" | grep HostMin | awk '{print $2;}')
+    hostip=$(ipcalc "$prefix" | grep HostMax | awk '{print $2;}')
     fprefix=$(echo "$prefix" | sed -e "s|.[0-9]*/[0-9-]*|.0/24|")
 fi
 


### PR DESCRIPTION
The -n and -b flags are not needed, because the broadcast address and network address are provided by default (if available). Meanwhile, on some ipcalc implementations those flags block other necessary fields from appearing.