### PR TITLE
fix: make POSIX compliant shebangs

### DIFF
--- a/scripts/peering-app
+++ b/scripts/peering-app
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 usage () {

--- a/scripts/peering-bgp
+++ b/scripts/peering-bgp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 usage () {

--- a/scripts/peering-openvpn
+++ b/scripts/peering-openvpn
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 usage () {

--- a/scripts/peering-prefix
+++ b/scripts/peering-prefix
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 # program=$(basename $0)

--- a/scripts/peering-proxy
+++ b/scripts/peering-proxy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 usage () {


### PR DESCRIPTION
/bin/bash is not guaranteed to be on a POSIX system but /usr/bin/env is.